### PR TITLE
Close database connection on app shutdown

### DIFF
--- a/src/typegoose-core.module.spec.ts
+++ b/src/typegoose-core.module.spec.ts
@@ -170,7 +170,7 @@ describe('TypegooseCoreModule', () => {
         get: moduleRefGet
       } as any);
 
-      await coreModule.onModuleDestroy();
+      await coreModule.onApplicationShutdown();
 
       expect(moduleRefGet).toHaveBeenCalledWith(DEFAULT_DB_CONNECTION_NAME);
       expect(closeMock).toHaveBeenCalledTimes(1);
@@ -181,7 +181,7 @@ describe('TypegooseCoreModule', () => {
         get: () => null,
       } as any);
 
-      await expect(() => coreModule.onModuleDestroy()).not.toThrow();
+      await expect(() => coreModule.onApplicationShutdown()).not.toThrow();
     });
   });
 });

--- a/src/typegoose-core.module.ts
+++ b/src/typegoose-core.module.ts
@@ -1,6 +1,6 @@
 import * as mongoose from 'mongoose';
 import { models } from '@typegoose/typegoose/lib/internal/data';
-import { DynamicModule, Global, Module, Provider, OnModuleDestroy, Inject } from '@nestjs/common';
+import { DynamicModule, Global, Module, Provider, OnApplicationShutdown, Inject } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { TypegooseOptionsFactory, TypegooseModuleOptions, TypegooseModuleAsyncOptions, TypegooseConnectionOptions } from './typegoose-options.interface';
 import { TYPEGOOSE_CONNECTION_NAME, TYPEGOOSE_MODULE_OPTIONS } from './typegoose.constants';
@@ -9,7 +9,7 @@ import { deleteModel } from '@typegoose/typegoose';
 
 @Global()
 @Module({})
-export class TypegooseCoreModule implements OnModuleDestroy {
+export class TypegooseCoreModule implements OnApplicationShutdown {
   constructor(
     @Inject(TYPEGOOSE_CONNECTION_NAME) private readonly connectionName: string,
     private readonly moduleRef: ModuleRef
@@ -99,7 +99,7 @@ export class TypegooseCoreModule implements OnModuleDestroy {
     };
   }
 
-  async onModuleDestroy() {
+  async onApplicationShutdown() {
     const connection = this.moduleRef.get<any>(this.connectionName);
 
     if (connection) {


### PR DESCRIPTION
What is the current behavior?

When closing a Nest http application, the order of hook is :
- `onModuleDestroy`
- `beforeApplicationShutdown`
- dispose http adapter
- `onApplicationShutdown`

The typegoose core module closes the database connections with the `onModuleDestroy` hook, before the dispose of http adapter. So, the connections to database are closed before the end of http active connections.

What is the new behavior?

The database connection are closed with the `onApplicationShutdown` hook after the end of http connection.

If have found a similar issue in : 
- @nestjs/typeorm project : https://github.com/nestjs/typeorm/pull/164
- @nestjs/mongoose project : https://github.com/nestjs/mongoose/pull/206