### PR TITLE
Fix example included in build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,10 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": [
-    "**/*spec.ts",
-    "dist",
-    "build"
-  ],
+  "exclude": ["**/*spec.ts", "dist", "build", "example"],
   "compilerOptions": {
     "outDir": "./dist"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,7 @@
     "baseUrl": "./",
     "incremental": true,
     "tsBuildInfoFile": ".tsbuildinfo",
-    "lib": [
-      "esnext"
-    ]
+    "lib": ["esnext"]
   },
-  "exclude": ["node_modules", "dist", "build"]
+  "exclude": ["node_modules", "dist", "build", "example"]
 }


### PR DESCRIPTION
Fixes error in master due to `example` being included in builds.