### PR TITLE
fiexd:修复连接参数错误问题

### DIFF
--- a/src/typegoose-options.interface.ts
+++ b/src/typegoose-options.interface.ts
@@ -1,8 +1,8 @@
 import { Type } from '@nestjs/common';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
-import { ConnectionOptions } from 'mongoose';
+import { ConnectOptions } from 'mongoose';
 
-export interface TypegooseConnectionOptions extends ConnectionOptions {
+export interface TypegooseConnectionOptions extends ConnectOptions {
   connectionName?: string;
 }
 


### PR DESCRIPTION
代码改动:
![image](https://user-images.githubusercontent.com/48984582/192434718-6cdadb6d-560e-47fb-a1de-3d297cb5b126.png)

改动原因:
原导入的字段查找不到:
![image](https://user-images.githubusercontent.com/48984582/192435534-67648462-4eb7-43e9-b650-344279294960.png)

修改后的可以:
![image](https://user-images.githubusercontent.com/48984582/192435392-76fb3a93-bc88-42cc-bd80-b1d8c62c42f3.png)

可能是mongoose库的更新导致的问题